### PR TITLE
docs: リファクタリング計画の策定 (RFC)

### DIFF
--- a/docs/plan/refactoring-plan.md
+++ b/docs/plan/refactoring-plan.md
@@ -254,9 +254,11 @@ def preprocess_translation_blocks()            # 前処理
 ```
 削除:
 ├── data/license.json        # ArXivライセンス検証（Web専用）
-├── data/indqx_qr.png        # QRコード（ロゴ機能削除時）
-├── debug/                   # デバッグ出力フォルダ
 └── Test Bench/              # テストベンチマーク
+
+維持:
+├── data/indqx_qr.png        # ロゴ機能で使用（維持）
+└── debug/                   # デバッグ出力（.gitignore に追加して維持）
 ```
 
 ---
@@ -555,7 +557,7 @@ if __name__ == "__main__":
 | Phase 1 | 不要ファイル削除 | 0.5日 |
 | Phase 2 | デバッグコード整理 | 0.5日 |
 | Phase 3 | config.py簡素化 | 0.5日 |
-| Phase 4 | requirements.txt整理 | 0.5日 |
+| Phase 4 | pip → uv 移行（pyproject.toml, uv.lock） | 0.5日 |
 | Phase 5 | CLI作成 | 1日 |
 | Phase 6 | コードリファクタリング | 1-2日 |
 | テスト | 動作確認 | 0.5日 |
@@ -615,3 +617,4 @@ if __name__ == "__main__":
 | 2024-12-04 | 1.1 | matplotlib維持、pip→uv移行を追加、デバッグ機能の整理 |
 | 2024-12-04 | 1.2 | ロゴ機能をデフォルトON、--no-logoでOFFに決定 |
 | 2024-12-04 | 1.3 | 見開きPDF生成を必須機能として維持に決定 |
+| 2024-12-04 | 1.4 | 削除リストとスケジュール表の整合性を修正 |


### PR DESCRIPTION
## 概要

Issue #8 に基づき、リファクタリング計画を詳細化したドキュメントを作成しました。

**本PRは計画の議論・レビュー用です。**

---

## 📄 追加ドキュメント

- `docs/plan/refactoring-plan.md` - 詳細なリファクタリング計画書

---

## 📋 計画概要

### 目標
Webサーバー向けライブラリから、シンプルな **PDF翻訳CLIツール** へ簡素化

### 主要な変更

| 項目 | Before | After |
|------|--------|-------|
| Pythonファイル数 | 10 | 4-5 |
| 総コード行数 | ~2,200 | ~700 |
| 依存パッケージ | 15+ | 5-6 |

### 実装フェーズ

| Phase | 内容 |
|-------|------|
| 1 | 不要ファイルの削除（Web専用モジュール） |
| 2 | デバッグコードの整理 |
| 3 | config.py の簡素化 |
| 4 | requirements.txt の整理 |
| 5 | CLIエントリーポイントの作成 |
| 6 | コードリファクタリング |

### 削除対象ファイル

- `demo_app.py` (FastAPI Webサーバー)
- `objective_DB_config.py` (Backblaze/DB設定)
- `modules/arxiv_api.py` (ArXiv連携)
- `modules/backblaze_api.py` (クラウドストレージ)
- `modules/database.py` (SQLAlchemy ORM)
- `modules/generate_fixed_key.py` (RSAキー生成)

---

## 🤔 議論したい点

### 1. write_logo_data() の扱い

現在、翻訳PDFにロゴ/QRコードを追加する機能があります。

- **オプションA**: 削除（シンプル化優先）
- **オプションB**: オプション化（`--no-logo` フラグ）

### 2. 見開きPDF生成

現在、オリジナルと翻訳を左右に並べた見開きPDFを生成します。

- **オプションA**: 必須機能として維持
- **オプションB**: オプション化（`--no-side-by-side` フラグ）

### 3. 新しいCLI引数設計

提案している引数:
```bash
python translate_pdf.py input.pdf
python translate_pdf.py input.pdf --output ./out.pdf
python translate_pdf.py input.pdf --source en --target ja
python translate_pdf.py input.pdf --no-side-by-side
python translate_pdf.py input.pdf --no-logo
```

他に必要な引数はありますか？

### 4. debug/ フォルダの扱い

- 開発時には便利だが、リリース版には不要
- `.gitignore` に追加してフォルダは残す案

---

## 📎 関連

- Issue #8: リファクタリング計画

---

## レビュー依頼

計画内容についてフィードバックをお願いします：

- [ ] 削除対象ファイルに問題はないか
- [ ] 維持すべき機能の漏れはないか
- [ ] CLIインターフェースの設計は適切か
- [ ] 実装フェーズの順序は適切か

🤖 Generated with [Claude Code](https://claude.com/claude-code)