### PR TITLE
refactor: Phase 2 - デバッグ/テストコードの削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,6 @@ python manual_translate_pdf.py
 ```
 Opens file dialog, translates selected PDF, saves to `./output/result_*.pdf`
 
-### Debug Mode
-In `manual_translate_pdf.py`, call `translate_test()` instead of `translate_local()` to generate visualization PDFs showing block classification (blue=body, green=figures, red=removed) in `./debug/`.
-
 ## Configuration
 
 **config.py** - Set your DeepL API key:

--- a/manual_translate_pdf.py
+++ b/manual_translate_pdf.py
@@ -1,26 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
-from modules.translate import pdf_translate,PDF_block_check,write_logo_data
-import os, asyncio,time
+from modules.translate import pdf_translate
+import os
+import asyncio
 import tkinter as tk
 from tkinter import filedialog
 from config import *
 
-def load_json_to_list(file_path):
-    import json
-    """ 指定されたJSONファイルを読み込み、Pythonのリストとして返す関数 """
-    try:
-        with open(file_path, 'r', encoding='utf-8') as file:
-            data = json.load(file)
-            return data
-    except FileNotFoundError:
-        print(f"指定されたファイルが見つかりません: {file_path}")
-        return None
-    except json.JSONDecodeError:
-        print("JSONファイルの形式が正しくありません。")
-        return None
-    except Exception as e:
-        print(f"ファイルの読み込み中にエラーが発生しました: {e}")
-        return None
 
 async def translate_local(deepl_url,deepl_key,disble_translate=False):
     # GUIでファイル選択のための設定
@@ -46,140 +31,5 @@ async def translate_local(deepl_url,deepl_key,disble_translate=False):
     with open(output_path, "wb") as f:
         f.write(result_pdf)
 
-async def translate_test(disble_translate=False):
-    # GUIでファイル選択のための設定
-    root = tk.Tk()
-    root.withdraw()  # GUIのメインウィンドウを表示しない
-    file_path = filedialog.askopenfilename(filetypes=[("PDF files", "*.pdf")])  # PDFファイルのみ選択
-
-    if not file_path:
-        print("ファイルが選択されませんでした。")
-        return
-    
-    process_time = time.time()
-    with open(file_path, "rb") as f:
-        input_pdf_data = f.read()
-
-    result_pdf = await pdf_translate(os.environ["DEEPL_API_KEY"], input_pdf_data,debug=True,disable_translate=disble_translate)
-
-    if result_pdf is None:
-        return
-    
-    _, file_name = os.path.split(file_path)
-    output_path = Debug_folder_path + "result_"+file_name
-
-    with open(output_path, "wb") as f:
-        f.write(result_pdf)
-    print(F"Time:{time.time()-process_time}")
-
-async def test_bench(disble_translate=False,debug=True):
-    original_directory = os.getcwd()
-    directory = ".\Test Bench\\raw"
-    import glob
-    # カレントディレクトリに変更する場合
-    os.chdir(directory)
-    # PDFファイルのフルパスを取得
-    pdf_files = glob.glob('**/*.pdf', recursive=True)
-    # ディレクトリをフルパスで取得するには、以下のように結合する
-    pdf_files = [os.path.join(directory, file) for file in pdf_files]
-    pdf_files = glob.glob('**/*.pdf', recursive=True)
-
-    # ディレクトリー移動
-    os.chdir(original_directory)
-
-    for file_path in pdf_files:
-        file_path = directory + "\\"+ file_path
-        with open(file_path, "rb") as f:
-            input_pdf_data = f.read()
-        print(F"\nLoaded: {file_path}")
-
-        result_pdf = await pdf_translate(os.environ["DEEPL_API_KEY"], input_pdf_data,debug=debug,disable_translate=disble_translate)
-
-        if result_pdf is None:
-            continue
-        _, file_name = os.path.split(file_path)
-        output_path = bach_process_path + "result_"+file_name
-
-        with open(output_path, "wb") as f:
-            f.write(result_pdf)
-        print(F"Saved: {output_path}")
-
-async def pdf_block_test():
-    # GUIでファイル選択のための設定
-    root = tk.Tk()
-    root.withdraw()  # GUIのメインウィンドウを表示しない
-    file_path = filedialog.askopenfilename(filetypes=[("PDF files", "*.pdf")])  # PDFファイルのみ選択
-
-    if not file_path:
-        print("ファイルが選択されませんでした。")
-        return
-    
-    with open(file_path, "rb") as f:
-        input_pdf_data = f.read()
-    result_pdf = await PDF_block_check(input_pdf_data)    
-
-    if result_pdf is None:
-        return
-    _, file_name = os.path.split(file_path)
-    output_path = Debug_folder_path + "Blocks_"+file_name
-
-    with open(output_path, "wb") as f:
-        f.write(result_pdf)
-
-async def pdf_block_bach():
-    original_directory = os.getcwd()
-    directory = ".\Test Bench\\raw"
-    import glob
-    # カレントディレクトリに変更する場合
-    os.chdir(directory)
-    # PDFファイルのフルパスを取得
-    pdf_files = glob.glob('**/*.pdf', recursive=True)
-    # ディレクトリをフルパスで取得するには、以下のように結合する
-    pdf_files = [os.path.join(directory, file) for file in pdf_files]
-    pdf_files = glob.glob('**/*.pdf', recursive=True)
-
-    # ディレクトリー移動
-    os.chdir(original_directory)
-
-    for file_path in pdf_files:
-        file_path = directory + "\\"+ file_path
-        with open(file_path, "rb") as f:
-            input_pdf_data = f.read()
-        print(F"Loaded: {file_path}")
-
-        result_pdf = await PDF_block_check(input_pdf_data)
-        result_pdf = await write_logo_data(result_pdf)
-
-        if result_pdf is None:
-            continue
-        _, file_name = os.path.split(file_path)
-        output_path = bach_process_path + "Blocks_"+file_name
-
-        with open(output_path, "wb") as f:
-            f.write(result_pdf)
-        print(F"Saved: {output_path}")
-
-async def marge_test():
-    base_path = "./Test Bench/raw/3page-Interactive Video Stylization Using Few-Shot Patch-Based Training.pdf"
-    tran_path = "./Test Bench/result/result_3page-Interactive Video Stylization Using Few-Shot Patch-Based Training.pdf"
-    with open(base_path, "rb") as f:
-        input_pdf_data_base = f.read()
-    with open(tran_path, "rb") as f:
-        input_pdf_data_tran = f.read()
-    from modules.pdf_edit import create_viewing_pdf
-    #
-    result_pdf = await create_viewing_pdf(input_pdf_data_base,input_pdf_data_tran)
-
-    with open("./marge_test.pdf", "wb") as f:
-        f.write(result_pdf)
-
 if __name__ == "__main__":
-    asyncio.run(translate_local(DeepL_URL,DeepL_API_Key))
-
-    #asyncio.run(translate_test(disble_translate=True))
-    #asyncio.run(translate_test(disble_translate=False))
-    #asyncio.run(test_bench(disble_translate=True,debug=True))
-    #asyncio.run(test_bench(disble_translate=False,debug=False))
-    #asyncio.run(pdf_block_bach())
-    #asyncio.run(marge_test())
-    
+    asyncio.run(translate_local(DeepL_URL, DeepL_API_Key))

--- a/modules/pdf_edit.py
+++ b/modules/pdf_edit.py
@@ -103,33 +103,6 @@ async def extract_text_coordinates_dict(pdf_data):
     await asyncio.to_thread(document.close)
     return content
 
-async def extract_text_coordinates_dict_dev(pdf_data):
-    """
-    デバッグ用。dictで取得したデータを出力します。
-    """
-    # PDFファイルを開く
-    document = await asyncio.to_thread(fitz.open, stream=pdf_data, filetype="pdf")
-
-    content = []
-    for page_num in range(len(document)):
-        # ページを取得
-        page = await asyncio.to_thread(document.load_page, page_num)
-        # ページからテキストブロックを取得
-        text_instances_dict = await asyncio.to_thread(page.get_text, "dict")
-        text_instances = text_instances_dict["blocks"]
-        page_content = []
-        
-        for lines in text_instances:
-            if lines["type"] != 0:
-                # テキストブロック以外はスキップ
-                continue
-            page_content.append(lines)
-        
-        content.append(page_content)
-
-    await asyncio.to_thread(document.close)
-    return content
-
 def check_first_num_tokens(input_list, keywords, num=2):
     for item in input_list[:num]:
         for keyword in keywords:
@@ -489,41 +462,6 @@ async def write_pdf_text(input_pdf_data, block_info, to_lang='en',text_color=[0,
 
     return output_data
 
-async def write_image_data(input_pdf_data,image_data,rect=(10,10,200,200),position=-1,add_new_page=True):
-    """
-    新しいページを作成し、画像を挿入します。
-    """
-    from PIL import Image
-    import io,os
-
-    doc = await asyncio.to_thread(fitz.open, stream=input_pdf_data, filetype="pdf")
-
-    # 最初のページの寸法を取得
-    first_page = doc[0]  # 最初のページを取得
-    rect = first_page.rect  # 最初のページの寸法を取得
-
-    # ページの追加
-    if add_new_page:
-        doc.insert_page(position, width=rect.width, height=rect.height)
-
-    page = doc[position]
-    image_byte = Image.open(io.BytesIO(image_data))
-    temp_image_path = "temp_image.png"
-    image_byte.save(temp_image_path)
-    page.insert_image(rect,filename=temp_image_path)
-
-    # 保存と終了処理
-    output_buffer = BytesIO()
-    await asyncio.to_thread(doc.save, output_buffer, garbage=4, deflate=True, clean=True)
-
-    # 一時ファイルの削除
-    os.remove(temp_image_path)  # temp_image.pngを削除
-    #ドキュメントのクローズ
-    await asyncio.to_thread(doc.close)
-    
-    # PDFデータをバイトとして返す
-    output_data = output_buffer.getvalue()
-    return output_data
 
 async def write_logo_data(input_pdf_data):
     """

--- a/modules/translate.py
+++ b/modules/translate.py
@@ -101,22 +101,7 @@ async def preprocess_translation_blocks(blocks,end_maker=(".",":",";"),end_maker
                 
         results.append(page_results)
     return results
-    
-async def deepl_convert_xml_calc_cost(json_data):
-    """
-    翻訳コストを算出します。
-    """
-    cost =0
-    price_per_character = 0.0025  # 1文字あたりの料金(円)
-    xml_output = ""
-    for page in json_data:
-        for block in page:
-            text = block['text']
-            # 翻訳にて問題になる文字列を変換
-            #text = text.replace('\n', '')
 
-            xml_output += f"<div>{text}</div>\n"
-    return xml_output,cost
 
 async def pdf_translate(key,pdf_data,source_lang = 'en',to_lang = 'ja',api_url="https://api.deepl.com/v2/translate",debug = False,disable_translate=False):
 
@@ -153,70 +138,8 @@ async def pdf_translate(key,pdf_data,source_lang = 'en',to_lang = 'ja',api_url="
         translated_pdf_data = await write_logo_data(translated_pdf_data)
     else:
         print("99.Translate is False")
-    
-    """
-    if debug:
-        import json
-        raw_blocks = await extract_text_coordinates_dict_dev(pdf_data)
-        with open(Debug_folder_path+'raw_blocks.json', 'w', encoding='utf-8') as json_file:
-            json.dump(raw_blocks, json_file, ensure_ascii=False, indent=2)
-        with open(Debug_folder_path+'all_blocks.json', 'w', encoding='utf-8') as json_file:
-            json.dump(block_info, json_file, ensure_ascii=False, indent=2)
-        with open(Debug_folder_path+'text_block.json', 'w', encoding='utf-8') as json_file:
-            json.dump(text_blocks, json_file, ensure_ascii=False, indent=2)
-        with open(Debug_folder_path+'fig_blocks.json', 'w', encoding='utf-8') as json_file:
-            json.dump(fig_blocks, json_file, ensure_ascii=False, indent=2)
-        with open(Debug_folder_path+'remove_info.json', 'w', encoding='utf-8') as json_file:
-            json.dump(remove_info, json_file, ensure_ascii=False, indent=2)
-        
-        if disable_translate is False:
-            with open(Debug_folder_path+'translate_text_blocks.json', 'w', encoding='utf-8') as json_file:
-                json.dump(translate_text_blocks, json_file, ensure_ascii=False, indent=2)
-            with open(Debug_folder_path+'translate_fig_blocks.json', 'w', encoding='utf-8') as json_file:
-                json.dump(translate_fig_blocks, json_file, ensure_ascii=False, indent=2)
-            with open(Debug_folder_path+'write_text_blocks.json', 'w', encoding='utf-8') as json_file:
-                json.dump(write_text_blocks, json_file, ensure_ascii=False, indent=2)
-            with open(Debug_folder_path+'write_fig_blocks.json', 'w', encoding='utf-8') as json_file:
-                json.dump(write_fig_blocks, json_file, ensure_ascii=False, indent=2)
-    
-        
-        text_block_pdf_data = await pdf_draw_blocks(pdf_data,text_blocks,width=0,fill_opacity=0.3,fill_colorRGB=[0,0,1])
-        fig_block_pdf_data = await pdf_draw_blocks(text_block_pdf_data,fig_blocks,width=0,fill_opacity=0.3,fill_colorRGB=[0,1,0])
-        all_block_pdf_data = await pdf_draw_blocks(fig_block_pdf_data,remove_info,width=0,fill_opacity=0.7,fill_colorRGB=[1,0,0])
-        
-        # グラフの描画
-        for image in plot_images:
-            all_block_pdf_data = await write_image_data(all_block_pdf_data,image,(10,10,410,410))
-            
-        with open(Debug_folder_path+"show_blocks.pdf", "wb") as f:
-            f.write(all_block_pdf_data)
-        with open(Debug_folder_path+"removed_pdf.pdf", "wb") as f:
-            f.write(removed_textbox_pdf_data)
-        
-        # block 消去理由を描画
-        if disable_translate is False:
-            translated_pdf_data = await write_pdf_text(translated_pdf_data,remove_info,text_color=[0,0,1],font_path="fonts/LiberationSerif-Bold.ttf")
-        else:
-            translated_pdf_data = await write_pdf_text(all_block_pdf_data,remove_info,text_color=[0,0,1],font_path="fonts/LiberationSerif-Bold.ttf")
-        return translated_pdf_data
-        """
-    
+
     # 見開き結合の実施
-    marged_pdf_data = await create_viewing_pdf(pdf_data,translated_pdf_data)
+    marged_pdf_data = await create_viewing_pdf(pdf_data, translated_pdf_data)
     print("5.Generate PDF Data")
     return marged_pdf_data
-
-async def PDF_block_check(pdf_data,source_lang = 'en'):
-    """
-    ブロックの枠を作画します
-    """
-
-    block_info = await extract_text_coordinates_dict(pdf_data)
-
-    text_blocks,fig_blocks,leave_blocks = await remove_blocks(block_info,10,lang=source_lang)
-        
-    text_block_pdf_data = await pdf_draw_blocks(pdf_data,text_blocks,width=0,fill_opacity=0.3,fill_colorRGB=[0,0,1])
-    fig_block_pdf_data = await pdf_draw_blocks(text_block_pdf_data,fig_blocks,width=0,fill_opacity=0.3,fill_colorRGB=[0,1,0])
-    all_block_pdf_data = await pdf_draw_blocks(fig_block_pdf_data,leave_blocks,width=0,fill_opacity=0.3,fill_colorRGB=[1,0,0])
-
-    return all_block_pdf_data


### PR DESCRIPTION
## 概要

リファクタリング計画 Phase 2: デバッグ/テストコードの整理

## 変更内容

### manual_translate_pdf.py (-152行)

| 削除項目 | 理由 |
|----------|------|
| `translate_test()` | デバッグ用テスト関数 |
| `test_bench()` | バッチテスト |
| `pdf_block_test()` | ブロック分類テスト |
| `pdf_block_bach()` | バッチ分類テスト |
| `marge_test()` | 見開き結合テスト |
| `load_json_to_list()` | 未使用ユーティリティ |
| コメントアウトされたテスト呼び出し | 不要 |

### modules/pdf_edit.py (-62行)

| 削除項目 | 理由 |
|----------|------|
| `extract_text_coordinates_dict_dev()` | デバッグ用生データ取得 |
| `write_image_data()` | 未使用の画像挿入機能 |

**維持したデバッグ機能:**
- `pdf_draw_blocks()`: ブロック枠描画（`--debug`で使用予定）
- `plot_area_distribution()`: ヒストグラム可視化（matplotlib）

### modules/translate.py (-81行)

| 削除項目 | 理由 |
|----------|------|
| `PDF_block_check()` | テスト関数のみで使用 |
| `deepl_convert_xml_calc_cost()` | 未使用のコスト計算 |
| コメントアウトされたデバッグブロック (~45行) | 不要 |

### CLAUDE.md (-3行)

- Debug Mode セクションを削除（削除した `translate_test()` を参照していたため）
- Phase 5 で `--debug` オプション追加時に再追加予定

## 削減サマリ

**合計: 298行削除**

| ファイル | 削除行数 |
|----------|----------|
| manual_translate_pdf.py | 152 |
| modules/translate.py | 81 |
| modules/pdf_edit.py | 62 |
| CLAUDE.md | 3 |

## 検証

- [x] 構文チェック（`py_compile`）: 通過
- [x] コア関数 (`translate_local`, `pdf_translate`) は維持
- [x] デバッグ関数 (`pdf_draw_blocks`, `plot_area_distribution`) は維持

## 関連

- Issue: #8
- 計画ドキュメント: [docs/plan/refactoring-plan.md](https://github.com/Mega-Gorilla/Index_PDF_Translation/blob/main/docs/plan/refactoring-plan.md)

## 次のPhase

Phase 3: config.py の簡素化

🤖 Generated with [Claude Code](https://claude.com/claude-code)