### PR TITLE
refactor: Phase 3 - config.py の簡素化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ Opens file dialog, translates selected PDF, saves to `./output/result_*.pdf`
 
 **config.py** - Set your DeepL API key:
 ```python
-DeepL_API_Key = "your-api-key"
-DeepL_URL = "https://api-free.deepl.com/v2/translate"  # or Pro URL
+DEEPL_API_KEY = "your-api-key"
+DEEPL_API_URL = "https://api-free.deepl.com/v2/translate"  # Pro: https://api.deepl.com/v2/translate
 ```
 
 ## Architecture

--- a/config.py
+++ b/config.py
@@ -1,36 +1,19 @@
-import os
-# config.py
-# ----- ローカル版 設定 ------
-DeepL_API_Key = "Your DeepL API Key"
-DeepL_URL = "https://api-free.deepl.com/v2/translate" # DeepL Proの場合は、「https://api.deepl.com/v2/translate」を設定してください
-Output_folder_path = "./output/"
+# SPDX-License-Identifier: AGPL-3.0-only
+"""
+Index PDF Translation - Configuration
 
-# ----- 以下 API用 設定 --------
+DeepL API設定と言語設定を管理します。
+"""
 
-# 接続許可リスト
-CORS_CONFIG = [
-    'https://indqx-demo-front.onrender.com',
-    'http://localhost:5173'
-]
+# DeepL API 設定
+DEEPL_API_KEY = "your-api-key"
+DEEPL_API_URL = "https://api-free.deepl.com/v2/translate"  # Pro: https://api.deepl.com/v2/translate
 
-#URLリスト
-URL_LIST = {
-    'papers_link':'https://indqx-demo-front.onrender.com/abs/'
+# 出力設定
+OUTPUT_DIR = "./output/"
+
+# 言語設定
+SUPPORTED_LANGUAGES = {
+    "en": {"deepl": "EN", "spacy": "en_core_web_sm"},
+    "ja": {"deepl": "JA", "spacy": "ja_core_news_sm"},
 }
-
-# 翻訳設定
-TRANSLATION_CONFIG = {
-    'ALLOWED_LANGUAGES':['en', 'ja']
-}
-
-#token 計算用
-SPACY_CONFIG = {
-    'supported_languages': {
-        'en': 'en_core_web_sm',
-        'ja': 'ja_core_news_sm'
-        }
-}
-
-# デバッグ用ファイル位置
-Debug_folder_path = "./debug/"
-bach_process_path = "./Test Bench/result/"

--- a/manual_translate_pdf.py
+++ b/manual_translate_pdf.py
@@ -4,10 +4,10 @@ import os
 import asyncio
 import tkinter as tk
 from tkinter import filedialog
-from config import *
+from config import DEEPL_API_KEY, DEEPL_API_URL, OUTPUT_DIR
 
 
-async def translate_local(deepl_url,deepl_key,disble_translate=False):
+async def translate_local(deepl_url, deepl_key, disable_translate=False):
     # GUIでファイル選択のための設定
     root = tk.Tk()
     root.withdraw()  # GUIのメインウィンドウを表示しない
@@ -20,16 +20,16 @@ async def translate_local(deepl_url,deepl_key,disble_translate=False):
     with open(file_path, "rb") as f:
         input_pdf_data = f.read()
 
-    result_pdf = await pdf_translate(deepl_key, input_pdf_data,api_url=deepl_url,debug=False,disable_translate=disble_translate)
+    result_pdf = await pdf_translate(deepl_key, input_pdf_data, api_url=deepl_url, debug=False, disable_translate=disable_translate)
 
     if result_pdf is None:
         return
     
     _, file_name = os.path.split(file_path)
-    output_path = Output_folder_path + "result_"+file_name
+    output_path = OUTPUT_DIR + "result_" + file_name
 
     with open(output_path, "wb") as f:
         f.write(result_pdf)
 
 if __name__ == "__main__":
-    asyncio.run(translate_local(DeepL_URL, DeepL_API_Key))
+    asyncio.run(translate_local(DEEPL_API_URL, DEEPL_API_KEY))

--- a/modules/spacy_api.py
+++ b/modules/spacy_api.py
@@ -1,8 +1,5 @@
 import spacy
-from config import SPACY_CONFIG
-
-# サポートされている言語とそのモデルのマッピング
-supported_languages = SPACY_CONFIG['supported_languages']
+from config import SUPPORTED_LANGUAGES
 
 # spaCyモデルをロードし、キャッシュしておく辞書
 loaded_models = {}
@@ -11,8 +8,8 @@ def load_model(lang_code):
     """指定された言語コードのモデルをロードする"""
     if lang_code in loaded_models:
         return loaded_models[lang_code]
-    if lang_code in supported_languages:
-        model_name = supported_languages[lang_code]
+    if lang_code in SUPPORTED_LANGUAGES:
+        model_name = SUPPORTED_LANGUAGES[lang_code]["spacy"]
         try:
             nlp = spacy.load(model_name)
             loaded_models[lang_code] = nlp

--- a/modules/translate.py
+++ b/modules/translate.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 import aiohttp
 import asyncio
-from config import *
 from modules.pdf_edit import *
 
 async def translate_str_data(key: str,text: str, target_lang: str,api_url:str) -> str:

--- a/readme.md
+++ b/readme.md
@@ -22,10 +22,11 @@ pip install -r requirements.txt
 
 ### APIキーの設定
 
-config.pyを開き、以下のDeepL_API_Keyを変更し、[https://www.deepl.com/ja/your-account/keys](https://www.deepl.com/ja/your-account/keys)より取得したDeepL API Keyを入力してください。
-また、DeepL API Proユーザーの場合、DeepL_URLをProAPI用URLに変更し保存してください。
-```
-DeepL_API_Key = "xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx:fx"
+config.pyを開き、`DEEPL_API_KEY`を変更し、[https://www.deepl.com/ja/your-account/keys](https://www.deepl.com/ja/your-account/keys)より取得したDeepL API Keyを入力してください。
+また、DeepL API Proユーザーの場合、`DEEPL_API_URL`をPro API用URLに変更し保存してください。
+```python
+DEEPL_API_KEY = "your-api-key"
+DEEPL_API_URL = "https://api-free.deepl.com/v2/translate"  # Pro: https://api.deepl.com/v2/translate
 ```
 
 ### フォント要件


### PR DESCRIPTION
## 概要

リファクタリング計画 Phase 3: config.py の簡素化

## 変更内容

### config.py (36行 → 19行, -47%)

**削除した設定:**

| 設定 | 理由 |
|------|------|
| `CORS_CONFIG` | Web専用（削除済み） |
| `URL_LIST` | Web専用（削除済み） |
| `TRANSLATION_CONFIG` | 未使用 |
| `Debug_folder_path` | テスト関数用（Phase 2で削除済み） |
| `bach_process_path` | テスト関数用（Phase 2で削除済み） |

**変数名の変更（Python命名規則に準拠）:**

| Before | After |
|--------|-------|
| `DeepL_API_Key` | `DEEPL_API_KEY` |
| `DeepL_URL` | `DEEPL_API_URL` |
| `Output_folder_path` | `OUTPUT_DIR` |
| `SPACY_CONFIG` | `SUPPORTED_LANGUAGES` に統合 |

**新しいconfig.py構造:**
```python
# DeepL API 設定
DEEPL_API_KEY = "your-api-key"
DEEPL_API_URL = "https://api-free.deepl.com/v2/translate"

# 出力設定
OUTPUT_DIR = "./output/"

# 言語設定
SUPPORTED_LANGUAGES = {
    "en": {"deepl": "EN", "spacy": "en_core_web_sm"},
    "ja": {"deepl": "JA", "spacy": "ja_core_news_sm"},
}
```

### 関連ファイルの更新

| ファイル | 変更内容 |
|----------|----------|
| `manual_translate_pdf.py` | 変数名更新、typo修正 (`disble_translate` → `disable_translate`) |
| `modules/spacy_api.py` | `SUPPORTED_LANGUAGES["lang"]["spacy"]` を使用 |
| `modules/translate.py` | 未使用の `from config import *` を削除 |
| `CLAUDE.md` | 設定例を更新 |
| `readme.md` | 設定例を更新 |

## 検証

- [x] 構文チェック（`py_compile`）: 通過
- [x] インポート整理: 具体的なインポートに変更 (`from config import *` → 明示的インポート)

## 削減サマリ

**config.py: 36行 → 19行 (-47%)**

## 関連

- Issue: #8
- 計画ドキュメント: [docs/plan/refactoring-plan.md](https://github.com/Mega-Gorilla/Index_PDF_Translation/blob/main/docs/plan/refactoring-plan.md)

## 次のPhase

Phase 4: pip → uv 移行

🤖 Generated with [Claude Code](https://claude.com/claude-code)