### PR TITLE
feat: Phase 5 - migrate CLI to entry_points-based command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,12 @@ python -m spacy download ja_core_news_sm
 ### Run Local Translation (CLI)
 ```bash
 # Basic usage
-uv run python translate_pdf.py paper.pdf
+uv run translate-pdf paper.pdf
 
 # With options
-uv run python translate_pdf.py paper.pdf -o ./result.pdf
-uv run python translate_pdf.py paper.pdf --source en --target ja
-uv run python translate_pdf.py paper.pdf --no-logo --debug
+uv run translate-pdf paper.pdf -o ./result.pdf
+uv run translate-pdf paper.pdf --source en --target ja
+uv run translate-pdf paper.pdf --no-logo --debug
 ```
 Translates PDF and saves side-by-side PDF to `./output/translated_*.pdf`
 
@@ -47,37 +47,40 @@ Translates PDF and saves side-by-side PDF to `./output/translated_*.pdf`
 - `-o, --output`: Output file path
 - `-s, --source`: Source language (en/ja, default: en)
 - `-t, --target`: Target language (en/ja, default: ja)
+- `--api-key`: DeepL API key (or use DEEPL_API_KEY env var)
+- `--api-url`: DeepL API URL (for Pro users)
 - `--no-logo`: Disable logo watermark
 - `--debug`: Enable debug mode (generate visualization PDFs)
 
 ## Configuration
 
-**config.py** - Set your DeepL API key:
-```python
-DEEPL_API_KEY = "your-api-key"
-DEEPL_API_URL = "https://api-free.deepl.com/v2/translate"  # Pro: https://api.deepl.com/v2/translate
+Set your DeepL API key via environment variable:
+```bash
+export DEEPL_API_KEY="your-api-key"
+# For Pro API users:
+export DEEPL_API_URL="https://api.deepl.com/v2/translate"
 ```
 
 ## Architecture
 
-### Core Modules (`modules/`)
+### Core Modules (`src/index_pdf_translation/`)
 
-- **pdf_edit.py** - PDF processing engine using PyMuPDF (fitz)
+- **core/pdf_edit.py** - PDF processing engine using PyMuPDF (fitz)
   - Text extraction with spatial coordinates
   - Histogram-based block classification (Sturges/Freedman-Diaconis binning)
   - Text removal and reinsertion with auto font sizing
   - Side-by-side PDF layout generation
 
-- **translate.py** - Translation orchestration
+- **core/translate.py** - Translation orchestration
   - DeepL API integration
   - Cross-block sentence merging (handles text spanning pages/blocks)
   - Main workflow: extract → filter → remove → translate → insert → layout
 
-- **spacy_api.py** - Language tokenization (en_core_web_sm, ja_core_news_sm)
+- **nlp/tokenizer.py** - Language tokenization (en_core_web_sm, ja_core_news_sm)
 
 ### Entry Points
 
-- **translate_pdf.py** - CLI tool for local PDF translation (argparse-based)
+- **cli.py** - CLI tool (`translate-pdf` command) via entry_points
 
 ### Translation Algorithm
 
@@ -92,4 +95,5 @@ DEEPL_API_URL = "https://api-free.deepl.com/v2/translate"  # Pro: https://api.de
 ### Key Technical Details
 
 - All I/O operations use `asyncio.to_thread()` for async execution
-- Font files in `fonts/` for Japanese (ipam.ttf) and English (Liberation Serif)
+- Font files bundled in `resources/fonts/` for Japanese (ipam.ttf) and English (Liberation Serif)
+- Resources accessed via `importlib.resources` for proper package installation support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,8 @@ dev = [
     "ruff>=0.1.0",
 ]
 
-# CLI entry point will be added in Phase 5
-# [project.scripts]
-# translate-pdf = "index_pdf_translation.cli:main"
+[project.scripts]
+translate-pdf = "index_pdf_translation.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/readme.md
+++ b/readme.md
@@ -57,10 +57,10 @@ export DEEPL_API_URL="https://api.deepl.com/v2/translate"
 #### 方法2: コマンドラインオプション
 
 ```bash
-uv run python translate_pdf.py paper.pdf --api-key "your-api-key"
+uv run translate-pdf paper.pdf --api-key "your-api-key"
 
 # DeepL API Proユーザーの場合
-uv run python translate_pdf.py paper.pdf --api-key "your-api-key" --api-url "https://api.deepl.com/v2/translate"
+uv run translate-pdf paper.pdf --api-key "your-api-key" --api-url "https://api.deepl.com/v2/translate"
 ```
 
 ## 使用方法
@@ -69,10 +69,10 @@ uv run python translate_pdf.py paper.pdf --api-key "your-api-key" --api-url "htt
 
 ```bash
 # uv を使用する場合（推奨）
-uv run python translate_pdf.py paper.pdf
+uv run translate-pdf paper.pdf
 
-# pip を使用する場合
-python translate_pdf.py paper.pdf
+# pip でインストールした場合
+translate-pdf paper.pdf
 ```
 
 翻訳が完了すると、`./output/translated_<ファイル名>.pdf` に見開きPDF（オリジナル + 翻訳）が保存されます。
@@ -93,13 +93,13 @@ python translate_pdf.py paper.pdf
 
 ```bash
 # 出力ファイルを指定
-uv run python translate_pdf.py paper.pdf -o ./result.pdf
+uv run translate-pdf paper.pdf -o ./result.pdf
 
 # 日本語から英語に翻訳
-uv run python translate_pdf.py paper.pdf -s ja -t en
+uv run translate-pdf paper.pdf -s ja -t en
 
 # ロゴなし + デバッグモード
-uv run python translate_pdf.py paper.pdf --no-logo --debug
+uv run translate-pdf paper.pdf --no-logo --debug
 ```
 
 ## アーキテクチャ
@@ -108,9 +108,10 @@ uv run python translate_pdf.py paper.pdf --no-logo --debug
 
 ```
 Index_PDF_Translation/
-├── translate_pdf.py                   # CLIエントリーポイント
 ├── src/index_pdf_translation/         # パッケージ本体
 │   ├── __init__.py                    # 公開API
+│   ├── cli.py                         # CLIエントリーポイント
+│   ├── config.py                      # 設定管理
 │   ├── core/
 │   │   ├── translate.py               # 翻訳オーケストレーション
 │   │   └── pdf_edit.py                # PDF処理エンジン（PyMuPDF）
@@ -216,7 +217,7 @@ Font file not found: LiberationSerif-Regular.ttf
 uv sync --extra dev
 
 # 構文チェック
-uv run python -m py_compile translate_pdf.py
+uv run python -m py_compile src/index_pdf_translation/cli.py
 ```
 
 ### コード規約

--- a/src/index_pdf_translation/cli.py
+++ b/src/index_pdf_translation/cli.py
@@ -6,14 +6,13 @@ Index PDF Translation - CLI Tool
 学術論文PDFを翻訳し、見開きPDF（オリジナル + 翻訳）を生成します。
 
 Usage:
-    python translate_pdf.py <input.pdf> [options]
-    uv run python translate_pdf.py <input.pdf> [options]
+    translate-pdf <input.pdf> [options]
 
 Examples:
-    python translate_pdf.py paper.pdf
-    python translate_pdf.py paper.pdf -o ./translated.pdf
-    python translate_pdf.py paper.pdf --source en --target ja
-    python translate_pdf.py paper.pdf --no-logo --debug
+    translate-pdf paper.pdf
+    translate-pdf paper.pdf -o ./translated.pdf
+    translate-pdf paper.pdf --source en --target ja
+    translate-pdf paper.pdf --no-logo --debug
 
 Environment Variables:
     DEEPL_API_KEY: DeepL APIキー (必須)
@@ -43,7 +42,7 @@ def parse_args() -> argparse.Namespace:
         パースされた引数のNamespace
     """
     parser = argparse.ArgumentParser(
-        prog="translate_pdf",
+        prog="translate-pdf",
         description="PDF翻訳ツール - 学術論文PDFを翻訳し見開きPDFを生成",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -114,7 +113,7 @@ Environment Variables:
     return parser.parse_args()
 
 
-async def translate(args: argparse.Namespace) -> int:
+async def run(args: argparse.Namespace) -> int:
     """
     PDFを翻訳します。
 
@@ -211,7 +210,7 @@ async def translate(args: argparse.Namespace) -> int:
 def main() -> NoReturn:
     """メインエントリーポイント。"""
     args = parse_args()
-    exit_code = asyncio.run(translate(args))
+    exit_code = asyncio.run(run(args))
     sys.exit(exit_code)
 
 


### PR DESCRIPTION
## Summary

- Add `cli.py` inside package with full CLI implementation (migrated from root `translate_pdf.py`)
- Enable `[project.scripts]` entry_point for `translate-pdf` command
- Delete root `translate_pdf.py` (no longer needed)
- Update README.md and CLAUDE.md documentation

## Changes

### New: `src/index_pdf_translation/cli.py`
- Complete CLI implementation moved into the package
- Uses `TranslationConfig` for settings management
- Supports `--api-key` and `--api-url` options
- Full error handling and progress display

### Modified: `pyproject.toml`
- Enabled `[project.scripts]` entry_point:
  ```toml
  [project.scripts]
  translate-pdf = "index_pdf_translation.cli:main"
  ```

### Deleted: `translate_pdf.py`
- Moved to `src/index_pdf_translation/cli.py`

### Documentation Updates
- Updated all CLI usage examples to use `translate-pdf` instead of `python translate_pdf.py`
- Updated file structure diagram
- Updated configuration section

## Test plan

- [x] `uv sync` installs package with entry_point
- [x] `translate-pdf --help` displays help message
- [x] Error handling for missing file works
- [x] Error handling for missing API key works

## Phase 5 Completion

Phase 5 completion conditions from the plan:
- [x] `translate-pdf paper.pdf` が動作
- [x] `DEEPL_API_KEY` 環境変数で認証
- [x] ルートの `translate_pdf.py` 削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)